### PR TITLE
Made motion calculation consistent

### DIFF
--- a/src/Data/Algorithm/Diff3.hs
+++ b/src/Data/Algorithm/Diff3.hs
@@ -118,7 +118,7 @@ incurMotion :: Int -> [Diff a] -> ([Diff a], [Diff a])
 incurMotion _ [] = ([], [])
 incurMotion 0 as  = ([], as)
 incurMotion n (a@(Both _ _):as) = ([a], []) <> incurMotion (pred n) as
-incurMotion n (a@(Second _):as) = ([a], []) <> incurMotion (pred n) as
+incurMotion n (a@(First _):as) = ([a], []) <> incurMotion (pred n) as
 incurMotion n (a:as) = ([a], []) <> incurMotion n as
 
 

--- a/test/properties.hs
+++ b/test/properties.hs
@@ -21,6 +21,40 @@ identicalChanges changed original = (changed /= original) ==>
 identityMerge :: [Int] -> Bool
 identityMerge as = merge (diff3 as as as) == Right as
 
+-- The value in `Just a` has to match the next list item
+-- `Nothing` is a wildcard that can match zero or more list items
+matching :: (Eq a) => [Maybe a] -> [a] -> Bool
+matching [] [] = True
+matching [] bs = False
+matching (Just a:as) (b:bs) = a == b && matching as bs
+matching (Just a:as) [] = False
+matching (as@(Nothing:as')) (bs@(_:bs')) = matching as' bs || matching as bs'
+matching (Nothing:as') (bs@[]) = matching as' bs
+
+matchLeft :: [Int] -> [Int] -> [Int] -> Bool
+matchLeft left original right = matching (matcher $ diff3 left original right) left
+  where matcher [] = []
+        matcher (LeftChange as:hs) = map Just as ++ matcher hs
+        matcher (RightChange as:hs) = Nothing : matcher hs
+        matcher (Unchanged as:hs) = map Just as ++ matcher hs
+        matcher (Conflict as os bs:hs) = map Just as ++ matcher hs
+
+matchRight :: [Int] -> [Int] -> [Int] -> Bool
+matchRight left original right = matching (matcher $ diff3 left original right) right
+  where matcher [] = []
+        matcher (LeftChange as:hs) = Nothing : matcher hs
+        matcher (RightChange as:hs) = map Just as ++ matcher hs
+        matcher (Unchanged as:hs) = map Just as ++ matcher hs
+        matcher (Conflict as os bs:hs) = map Just bs ++ matcher hs
+
+matchOriginal :: [Int] -> [Int] -> [Int] -> Bool
+matchOriginal left original right = matching (matcher $ diff3 left original right) original
+  where matcher [] = []
+        matcher (LeftChange as:hs) = Nothing : matcher hs
+        matcher (RightChange as:hs) = Nothing : matcher hs
+        matcher (Unchanged as:hs) = map Just as ++ matcher hs
+        matcher (Conflict as os bs:hs) = map Just os ++ matcher hs
+
 main :: IO ()
 main =
   let testOpts = mempty { topt_maximum_generated_tests = Just 1000 }
@@ -30,5 +64,8 @@ main =
        , testProperty "Can make changes in right document" rightChanges
        , testProperty "Left/right identical changes conflict" identicalChanges
        , testProperty "The 'identity' merge always succeeds" identityMerge
+       , testProperty "Left side of diff is part of left input" matchLeft
+       , testProperty "Right side of diff is part of right input" matchRight
+       , testProperty "Original parts of diff are part of original input" matchOriginal
        ]
        runner


### PR DESCRIPTION
The `motion` function in `shortestConflict` counts how many elements of the _first_ sequence are in a part of a diff. The function `incurMotion` then tries to advance by that many elements, but counts  elements in the _second_ sequence of the diff.

This leads to inconsistent/wrong diffs:

``` haskell
GHCi> diff3 "145" "12345" "1245"
[Unchanged "1",Conflict "" "23" "24",Unchanged "4",LeftChange "5"]
```

Here `4` is mentioned in the conflict as well as afterwards as unchanged. The training `LeftChange 5` is really unchanged.

With swapped arguments:

``` haskell
GHCi> diff3 "1245" "12345" "145"
[Unchanged "1",Conflict "24" "234" "",Unchanged "5",RightChange "5"]
```

Here `4` is (unnecessarily) incorporated in the conflict and `5` is mentioned twice.

This pull request fixes the counting in `incurMotion`, correcting the above examples:

``` haskell
GHCi> diff3 "1245" "12345" "145"
[Unchanged "1",Conflict "2" "23" "",Unchanged "45"]
GHCi> diff3 "145" "12345" "1245"
[Unchanged "1",Conflict "" "23" "2",Unchanged "45"]
```
