### PR TITLE
Made conflicts shorter

### DIFF
--- a/src/Data/Algorithm/Diff3.hs
+++ b/src/Data/Algorithm/Diff3.hs
@@ -100,8 +100,8 @@ shortestConflict l r =
           (bs, tb) = break isBoth b
           am = sum $ map motion as
           bm = sum $ map motion bs
-          (as', ta') = incurMotion bm ta
-          (bs', tb') = incurMotion am tb
+          (as', ta') = if bm > am then incurMotion (bm-am) ta else ([], ta)
+          (bs', tb') = if am > bm then incurMotion (am-bm) tb else ([], tb)
       in if am == bm
          then ((as, bs), ta, tb)
          else ((as ++ as', bs ++ bs'), [], []) <> go ta' tb'


### PR DESCRIPTION
Conflicts sometimes include more elements than necessary:

``` haskell
GHCi> diff3 "14567" "1234567" "1567"
[Unchanged "1",Conflict "456" "23456" "56",Unchanged "7"]
```

`56` shouldn't be included in the conflict.

This patch fixes the issue by only including additional elements for the diff that is "behind", instead of both diffs. It advances only the minimal amount necessary to bring both diffs in sync when searching for the end of a conflict.

This way less items are included in the conflict:

``` haskell
GHCi> diff3 "14567" "1234567" "1567"
[Unchanged "1",Conflict "4" "234" "",Unchanged "567"]
```
